### PR TITLE
Add support for OpenAI-compatible chat completion APIs with tool calling

### DIFF
--- a/src/AI-ChatPharo/ChatPharo.class.st
+++ b/src/AI-ChatPharo/ChatPharo.class.st
@@ -21,6 +21,12 @@ Class {
 	#tag : 'Spec'
 }
 
+{ #category : 'instance creation' }
+ChatPharo class >> new [
+
+	^ self on:  OllamaApi new
+]
+
 { #category : 'examples' }
 ChatPharo class >> open [
 	<example>
@@ -85,7 +91,6 @@ ChatPharo >> initialExtent [
 ChatPharo >> initializePresenters [ 
     notebook := self newNotebook.
     toolbar := self newToolbar.
-	 ollamaModel := OllamaApi new.
     
     toolbar add: (SpToolbarButtonPresenter new
         label: 'New Chat';
@@ -220,6 +225,12 @@ ChatPharo >> saveCurrentChat [
             nextPutAll: jsonData;
             close
     ]
+]
+
+{ #category : 'accessing - model' }
+ChatPharo >> setModelBeforeInitialization: initialOllamaModel [
+
+	ollamaModel := initialOllamaModel
 ]
 
 { #category : 'initialization' }

--- a/src/AI-ChatPharo/ChatPharo.class.st
+++ b/src/AI-ChatPharo/ChatPharo.class.st
@@ -183,7 +183,7 @@ ChatPharo >> ollamaModelSelect [
 	"Add to ChatPharo a select ollama model"
 	^ SpDropListPresenter new
 			help: 'Select ollama model';
-			items: OllamaApi modelNames;
+			items: self ollamaModel modelNames;
 			display: [ :e | e  ];
 			whenSelectedItemChangedDo: [ :ollamaModelName | self ollamaModel model: ollamaModelName];
 			yourself

--- a/src/AI-ChatPharo/ChatPharoHistorySaver.class.st
+++ b/src/AI-ChatPharo/ChatPharoHistorySaver.class.st
@@ -6,7 +6,8 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'role',
-		'content'
+		'content',
+		'toolCalls'
 	],
 	#category : 'AI-ChatPharo-API',
 	#package : 'AI-ChatPharo',
@@ -16,10 +17,17 @@ Class {
 { #category : 'instance creation' }
 ChatPharoHistorySaver class >> role: aRole content: aContent [
 
+	^ self role: aRole content: aContent toolCalls: nil
+]
+
+{ #category : 'instance creation' }
+ChatPharoHistorySaver class >> role: role content: content toolCalls: toolCalls [
+
 	^ self new
-		  role: aRole;
-		  content: aContent;
-		  yourself
+		role: role;
+		content: content;
+		toolCalls: toolCalls;
+		yourself
 ]
 
 { #category : 'converting' }
@@ -45,9 +53,19 @@ ChatPharoHistorySaver >> historyStringOn: stream [
 ]
 
 { #category : 'openAI API' }
-ChatPharoHistorySaver >> putOpenAIChatMessageOn: stream [
+ChatPharoHistorySaver >> putOpenAIChatMessagesOn: stream [
 
-	stream nextPut: (Dictionary with: 'role' -> self role with: 'content' -> self content)
+	| message |
+
+	message := Dictionary with: 'role' -> role.
+	content ifNotNil: [
+		message add: 'content' -> content ].
+	toolCalls ifNotNil: [
+		message add: 'tool_calls' -> (toolCalls collect: [ :toolCall | toolCall openAIChatToolCall ] as: Array) ].
+	stream nextPut: message.
+	toolCalls ifNotNil: [
+		toolCalls do: [ :toolCall |
+			stream nextPut: toolCall openAIChatToolMessage ] ].
 ]
 
 { #category : 'converting' }
@@ -60,4 +78,23 @@ ChatPharoHistorySaver >> role [
 ChatPharoHistorySaver >> role: anObject [
 
 	role := anObject
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaver >> toolCalls [
+
+	^ toolCalls
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaver >> toolCalls: newToolCalls [
+
+	toolCalls := newToolCalls
+]
+
+{ #category : 'displaying' }
+ChatPharoHistorySaver >> toolCallsDisplay [
+
+	^ toolCalls ifNotNil: [
+		'(tools called: {1})' format: { ', ' join: (toolCalls collect: [ :toolCall | toolCall functionName ]) } ]
 ]

--- a/src/AI-ChatPharo/ChatPharoHistorySaver.class.st
+++ b/src/AI-ChatPharo/ChatPharoHistorySaver.class.st
@@ -44,6 +44,12 @@ ChatPharoHistorySaver >> historyStringOn: stream [
 		nextPutAll: String cr.
 ]
 
+{ #category : 'openAI API' }
+ChatPharoHistorySaver >> putOpenAIChatMessageOn: stream [
+
+	stream nextPut: (Dictionary with: 'role' -> self role with: 'content' -> self content)
+]
+
 { #category : 'converting' }
 ChatPharoHistorySaver >> role [
 

--- a/src/AI-ChatPharo/ChatPharoHistorySaverToolCall.class.st
+++ b/src/AI-ChatPharo/ChatPharoHistorySaverToolCall.class.st
@@ -1,0 +1,68 @@
+Class {
+	#name : 'ChatPharoHistorySaverToolCall',
+	#superclass : 'Object',
+	#instVars : [
+		'id',
+		'functionName',
+		'arguments',
+		'content'
+	],
+	#category : 'AI-ChatPharo-API',
+	#package : 'AI-ChatPharo',
+	#tag : 'API'
+}
+
+{ #category : 'instance creation' }
+ChatPharoHistorySaverToolCall class >> id: id functionName: functionName arguments: arguments content: content [
+
+	^ self basicNew initializeWithID: id functionName: functionName arguments: arguments content: content; yourself
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaverToolCall >> arguments [
+
+	^ arguments
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaverToolCall >> content [
+
+	^ content
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaverToolCall >> functionName [
+
+	^ functionName
+]
+
+{ #category : 'accessing' }
+ChatPharoHistorySaverToolCall >> id [
+
+	^ id
+]
+
+{ #category : 'initialization' }
+ChatPharoHistorySaverToolCall >> initializeWithID: initialID functionName: initialFunctionName arguments: initialArguments content: initialContent [
+
+	self initialize.
+	id := initialID.
+	functionName := initialFunctionName.
+	arguments := initialArguments.
+	content := initialContent.
+]
+
+{ #category : 'openAI API' }
+ChatPharoHistorySaverToolCall >> openAIChatToolCall [
+
+	^ Dictionary
+		with: 'type' -> 'function'
+		with: 'id' -> id
+		with: 'function' -> (Dictionary with: 'name' -> functionName with: 'arguments' -> arguments)
+]
+
+{ #category : 'openAI API' }
+ChatPharoHistorySaverToolCall >> openAIChatToolMessage [
+
+	^ Dictionary with: 'role' -> 'tool' with: 'tool_call_id' -> id with: 'content' -> content
+]

--- a/src/AI-ChatPharo/ChatPharoSpecChat.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChat.class.st
@@ -59,9 +59,11 @@ ChatPharoSpecChat >> askLocalModel [
                             content: inputField text).
 	ollamaProcess := [
 			inputField text: '(ollama model running)'.
-			result := self ollamaModel getResponseForHistory: history.
+			[
+				result := self ollamaModel getResponseForHistory: history.
+				history addMessage: result.
+			] doWhileTrue: [ result toolCalls notNil ].
 			inputField text: ''.
-			history addMessage: result.
 		] fork.
 ]
 

--- a/src/AI-ChatPharo/ChatPharoSpecChat.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChat.class.st
@@ -59,8 +59,7 @@ ChatPharoSpecChat >> askLocalModel [
                             content: inputField text).
 	ollamaProcess := [
 			inputField text: '(ollama model running)'.
-			self ollamaModel promptPrefix: history asPromptPrefix.
-			result := self ollamaModel getResponseForPrompt: nil.
+			result := self ollamaModel getResponseForHistory: history.
 			inputField text: ''.
 			history addMessage: (ChatPharoHistorySaver
                             role: 'assistant'

--- a/src/AI-ChatPharo/ChatPharoSpecChat.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChat.class.st
@@ -61,9 +61,7 @@ ChatPharoSpecChat >> askLocalModel [
 			inputField text: '(ollama model running)'.
 			result := self ollamaModel getResponseForHistory: history.
 			inputField text: ''.
-			history addMessage: (ChatPharoHistorySaver
-                            role: 'assistant'
-                            content: result).
+			history addMessage: result.
 		] fork.
 ]
 

--- a/src/AI-ChatPharo/ChatPharoSpecChat.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChat.class.st
@@ -57,11 +57,10 @@ ChatPharoSpecChat >> askLocalModel [
 	history addMessage: (ChatPharoHistorySaver
                             role: 'user'
                             content: inputField text).
-	ollamaProcess := [ | prompt |
-			prompt := inputField text.
+	ollamaProcess := [
 			inputField text: '(ollama model running)'.
 			self ollamaModel promptPrefix: history asPromptPrefix.
-			result := self ollamaModel getResponseForPrompt: prompt.
+			result := self ollamaModel getResponseForPrompt: nil.
 			inputField text: ''.
 			history addMessage: (ChatPharoHistorySaver
                             role: 'assistant'

--- a/src/AI-ChatPharo/ChatPharoSpecChatBubble.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChatBubble.class.st
@@ -46,6 +46,8 @@ ChatPharoSpecChatBubble >> defaultLayout [
 	modelName := self spParent ollamaModel model.
 	displayRole := self model role.
 	displayRole = 'assistant' ifTrue: [ displayRole := displayRole , ' (' , modelName , ')'].
+ 	self model toolCallsDisplay ifNotNil: [ :toolCallsDisplay |
+		displayRole := displayRole , ' ' , toolCallsDisplay ].
 	^ SpBoxLayout newTopToBottom
 		  add: displayRole expand: false;
 		  add: contentArea
@@ -57,7 +59,7 @@ ChatPharoSpecChatBubble >> defaultLayout [
 { #category : 'initialization' }
 ChatPharoSpecChatBubble >> initializePresenters [
 	contentArea := MicrodownPresenter new.
-	contentArea document: (Microdown parse: self model content)
+	contentArea document: (Microdown parse: (self model content ifNil: [ '' ]))
 ]
 
 { #category : 'accessing' }

--- a/src/AI-ChatPharo/ChatPharoSpecChatHistory.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChatHistory.class.st
@@ -74,6 +74,12 @@ ChatPharoSpecChatHistory >> panel: anObject [
 	panel := anObject
 ]
 
+{ #category : 'openAI API' }
+ChatPharoSpecChatHistory >> putOpenAIChatMessagesOn: stream [
+
+	self model do: [ :historySaver | historySaver putOpenAIChatMessageOn: stream ]
+]
+
 { #category : 'accessing' }
 ChatPharoSpecChatHistory >> spParent [
 

--- a/src/AI-ChatPharo/ChatPharoSpecChatHistory.class.st
+++ b/src/AI-ChatPharo/ChatPharoSpecChatHistory.class.st
@@ -77,7 +77,7 @@ ChatPharoSpecChatHistory >> panel: anObject [
 { #category : 'openAI API' }
 ChatPharoSpecChatHistory >> putOpenAIChatMessagesOn: stream [
 
-	self model do: [ :historySaver | historySaver putOpenAIChatMessageOn: stream ]
+	self model do: [ :historySaver | historySaver putOpenAIChatMessagesOn: stream ]
 ]
 
 { #category : 'accessing' }

--- a/src/AI-ChatPharo/OllamaAPI.class.st
+++ b/src/AI-ChatPharo/OllamaAPI.class.st
@@ -52,7 +52,8 @@ OllamaApi class >> ollamaVersion [
 { #category : 'ollama models' }
 OllamaApi >> getResponseForHistory: history [
 
-	^ self promptPrefix: history asPromptPrefix; getResponseForPrompt: nil
+	^ ChatPharoHistorySaver role: 'assistant'
+		content: (self promptPrefix: history asPromptPrefix; getResponseForPrompt: nil)
 ]
 
 { #category : 'ollama models' }

--- a/src/AI-ChatPharo/OllamaAPI.class.st
+++ b/src/AI-ChatPharo/OllamaAPI.class.st
@@ -50,6 +50,12 @@ OllamaApi class >> ollamaVersion [
 ]
 
 { #category : 'ollama models' }
+OllamaApi >> getResponseForHistory: history [
+
+	^ self promptPrefix: history asPromptPrefix; getResponseForPrompt: nil
+]
+
+{ #category : 'ollama models' }
 OllamaApi >> getResponseForPrompt: prompt [
 	"Sends a prompt to an API, receives JSON response, and extracts the 'response' value"
 	| apiGenerateUrl jsonResponse requestDictionary requestBody|

--- a/src/AI-ChatPharo/OllamaAPI.class.st
+++ b/src/AI-ChatPharo/OllamaAPI.class.st
@@ -57,7 +57,9 @@ OllamaApi >> getResponseForPrompt: prompt [
 	requestDictionary := Dictionary newFrom:  { 
 		#model -> model.
 		#system -> self system.
-		#prompt -> (self promptPrefix , ' ', prompt).
+		#prompt -> (String streamContents: [ :stream |
+			stream nextPutAll: self promptPrefix.
+			prompt ifNotNil: [ stream nextPutAll: ' '; nextPutAll: prompt ] ]).
 		#stream -> false.
 		#options -> (Dictionary newFrom: {
     		#temperature -> 0})

--- a/src/AI-ChatPharo/OllamaAPI.class.st
+++ b/src/AI-ChatPharo/OllamaAPI.class.st
@@ -113,6 +113,12 @@ OllamaApi >> modelInformation [
 	^ response contents.
 ]
 
+{ #category : 'ollama models' }
+OllamaApi >> modelNames [
+
+	^ self class modelNames
+]
+
 { #category : 'accessing' }
 OllamaApi >> promptPrefix [
 

--- a/src/AI-ChatPharo/OpenAIChatAPI.class.st
+++ b/src/AI-ChatPharo/OpenAIChatAPI.class.st
@@ -5,7 +5,8 @@ Class {
 		'baseURL',
 		'apiKey',
 		'model',
-		'system'
+		'system',
+		'tools'
 	],
 	#category : 'AI-ChatPharo-OpenAI',
 	#package : 'AI-ChatPharo',
@@ -15,20 +16,38 @@ Class {
 { #category : 'instance creation' }
 OpenAIChatAPI class >> baseURL: baseURL apiKey: apiKey system: system [
 
-	^ self basicNew initializeWithBaseURL: baseURL apiKey: apiKey system: system; yourself
+	^ self baseURL: baseURL apiKey: apiKey system: system tools: nil
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> baseURL: baseURL apiKey: apiKey system: system tools: tools [
+
+	^ self basicNew initializeWithBaseURL: baseURL apiKey: apiKey system: system tools: tools; yourself
 ]
 
 { #category : 'instance creation' }
 OpenAIChatAPI class >> baseURL: baseURL system: system [
 
-	^ self baseURL: baseURL apiKey: nil system: system
+	^ self baseURL: baseURL system: system tools: nil
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> baseURL: baseURL system: system tools: tools [
+
+	^ self baseURL: baseURL apiKey: nil system: system tools: tools
 ]
 
 { #category : 'instance creation' }
 OpenAIChatAPI class >> geminiWithAPIKey: apiKey system: system [
 
+	^ self geminiWithAPIKey: apiKey system: system tools: nil
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> geminiWithAPIKey: apiKey system: system tools: tools [
+
 	^ self baseURL: (ZnUrl fromString: 'https://generativelanguage.googleapis.com/v1beta/openai')
-		apiKey: apiKey system: system
+		apiKey: apiKey system: system tools: tools
 ]
 
 { #category : 'instance creation' }
@@ -40,7 +59,22 @@ OpenAIChatAPI class >> new [
 { #category : 'instance creation' }
 OpenAIChatAPI class >> ollamaWithSystem: system [
 
-	^ self baseURL: (ZnUrl fromString: 'http://localhost:11434/v1') system: system
+	^ self ollamaWithSystem: system tools: nil
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> ollamaWithSystem: system tools: tools [
+
+	^ self baseURL: (ZnUrl fromString: 'http://localhost:11434/v1') system: system tools: tools
+]
+
+{ #category : 'private' }
+OpenAIChatAPI >> applyToolFunction: functionName arguments: arguments [
+
+	tools do: [ :tool |
+		tool name = functionName ifTrue: [
+			^ [ tool applyTo: arguments ] on: Error do: [ Dictionary with: 'error' -> 'Error' ] ] ].
+	^ Dictionary with: 'error' -> ('There is no function named "{1}"' format: { functionName })
 ]
 
 { #category : 'accessing' }
@@ -61,30 +95,36 @@ OpenAIChatAPI >> client [
 { #category : 'api' }
 OpenAIChatAPI >> getResponseForHistory: history [
 
-	| messages data response |
+	| messages data response message |
 
 	messages := Array streamContents: [ :stream |
 		system ifNotNil: [
 			stream nextPut: (Dictionary with: 'role' -> 'system' with: 'content' -> system) ].
 		history putOpenAIChatMessagesOn: stream ].
 	data := Dictionary with: 'model' -> model with: 'messages' -> messages.
+	tools ifNotNil: [
+		data add: 'tools' -> (tools collect: [ :tool | tool openAIChatTool ] as: Array);
+			add: 'tool_choice' -> 'auto' ].
 	response := self client addPath: #('chat' 'completions');
 		entity: (ZnEntity json: (STONJSON toString: data));
 		timeout: (Duration minutes: 5) asSeconds;
 		post;
 		response.
 	response isSuccess ifFalse: [ Error signal: 'Could not get chat completion' ].
+	message := ((STONJSON fromString: response contents) at: 'choices') first at: 'message'.
 	^ ChatPharoHistorySaver role: 'assistant'
-		content: ((((STONJSON fromString: response contents) at: 'choices') first at: 'message') at: 'content')
+		content: (message at: 'content' ifAbsent: [ nil ])
+		toolCalls: (self toolCallsFromMessage: message)
 ]
 
 { #category : 'initialization' }
-OpenAIChatAPI >> initializeWithBaseURL: initialBaseURL apiKey: initialAPIKey system: initialSystem [
+OpenAIChatAPI >> initializeWithBaseURL: initialBaseURL apiKey: initialAPIKey system: initialSystem tools: initialTools [
 
 	self initialize.
 	baseURL := initialBaseURL.
 	apiKey := initialAPIKey.
 	system := initialSystem.
+	tools := initialTools.
 	self model: self modelNames first.
 ]
 
@@ -114,4 +154,28 @@ OpenAIChatAPI >> modelNames [
 OpenAIChatAPI >> system [
 
 	^ system
+]
+
+{ #category : 'private' }
+OpenAIChatAPI >> toolCallsFromMessage: message [
+
+	^ message at: 'tool_calls'
+		ifPresent: [ :toolCalls |
+			toolCalls collect: [ :toolCall |
+				| function functionName arguments content |
+				function := toolCall at: 'function'.
+				functionName := function at: 'name'.
+				arguments := function at: 'arguments'.
+				content := STONJSON toString: (self applyToolFunction: functionName
+					arguments: ([ STONJSON fromString: arguments ] on: STONReaderError
+						do: [ Dictionary with: 'error' -> 'Invalid arguments' ])).
+				ChatPharoHistorySaverToolCall id: (toolCall at: 'id') functionName: functionName
+					arguments: arguments content: content ] ]
+		ifAbsent: [ nil ]
+]
+
+{ #category : 'accessing' }
+OpenAIChatAPI >> tools [
+
+	^ tools
 ]

--- a/src/AI-ChatPharo/OpenAIChatAPI.class.st
+++ b/src/AI-ChatPharo/OpenAIChatAPI.class.st
@@ -1,0 +1,100 @@
+Class {
+	#name : 'OpenAIChatAPI',
+	#superclass : 'Object',
+	#instVars : [
+		'baseURL',
+		'model',
+		'system'
+	],
+	#category : 'AI-ChatPharo-OpenAI',
+	#package : 'AI-ChatPharo',
+	#tag : 'OpenAI'
+}
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> baseURL: baseURL system: system [
+
+	^ self basicNew initializeWithBaseURL: baseURL system: system; yourself
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> new [
+
+	^ self ollamaWithSystem: nil
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> ollamaWithSystem: system [
+
+	^ self baseURL: (ZnUrl fromString: 'http://localhost:11434/v1') system: system
+]
+
+{ #category : 'accessing' }
+OpenAIChatAPI >> baseURL [
+
+	^ baseURL
+]
+
+{ #category : 'private' }
+OpenAIChatAPI >> client [
+
+	^ ZnClient new
+		url: baseURL;
+		yourself
+]
+
+{ #category : 'api' }
+OpenAIChatAPI >> getResponseForHistory: history [
+
+	| messages data response |
+
+	messages := Array streamContents: [ :stream |
+		system ifNotNil: [
+			stream nextPut: (Dictionary with: 'role' -> 'system' with: 'content' -> system) ].
+		history putOpenAIChatMessagesOn: stream ].
+	data := Dictionary with: 'model' -> model with: 'messages' -> messages.
+	response := self client addPath: #('chat' 'completions');
+		entity: (ZnEntity json: (STONJSON toString: data));
+		timeout: (Duration minutes: 5) asSeconds;
+		post;
+		response.
+	response isSuccess ifFalse: [ Error signal: 'Could not get chat completion' ].
+	^ (((STONJSON fromString: response contents) at: 'choices') first at: 'message') at: 'content'
+]
+
+{ #category : 'initialization' }
+OpenAIChatAPI >> initializeWithBaseURL: initialBaseURL system: initialSystem [
+
+	self initialize.
+	baseURL := initialBaseURL.
+	system := initialSystem.
+	self model: self modelNames first.
+]
+
+{ #category : 'accessing' }
+OpenAIChatAPI >> model [
+
+	^ model
+]
+
+{ #category : 'accessing' }
+OpenAIChatAPI >> model: newModel [
+
+	model := newModel
+]
+
+{ #category : 'api' }
+OpenAIChatAPI >> modelNames [
+
+	| response |
+
+	response := self client addPathSegment: 'models'; get; response.
+	response isSuccess ifFalse: [ Error signal: 'Could not retrieve models' ].
+	^ ((STONJSON fromString: response contents) at: 'data') collect: [ :modelObject | modelObject at: 'id' ]
+]
+
+{ #category : 'accessing' }
+OpenAIChatAPI >> system [
+
+	^ system
+]

--- a/src/AI-ChatPharo/OpenAIChatAPI.class.st
+++ b/src/AI-ChatPharo/OpenAIChatAPI.class.st
@@ -3,6 +3,7 @@ Class {
 	#superclass : 'Object',
 	#instVars : [
 		'baseURL',
+		'apiKey',
 		'model',
 		'system'
 	],
@@ -12,9 +13,22 @@ Class {
 }
 
 { #category : 'instance creation' }
+OpenAIChatAPI class >> baseURL: baseURL apiKey: apiKey system: system [
+
+	^ self basicNew initializeWithBaseURL: baseURL apiKey: apiKey system: system; yourself
+]
+
+{ #category : 'instance creation' }
 OpenAIChatAPI class >> baseURL: baseURL system: system [
 
-	^ self basicNew initializeWithBaseURL: baseURL system: system; yourself
+	^ self baseURL: baseURL apiKey: nil system: system
+]
+
+{ #category : 'instance creation' }
+OpenAIChatAPI class >> geminiWithAPIKey: apiKey system: system [
+
+	^ self baseURL: (ZnUrl fromString: 'https://generativelanguage.googleapis.com/v1beta/openai')
+		apiKey: apiKey system: system
 ]
 
 { #category : 'instance creation' }
@@ -40,6 +54,7 @@ OpenAIChatAPI >> client [
 
 	^ ZnClient new
 		url: baseURL;
+		setBearerAuthentication: apiKey;
 		yourself
 ]
 
@@ -63,10 +78,11 @@ OpenAIChatAPI >> getResponseForHistory: history [
 ]
 
 { #category : 'initialization' }
-OpenAIChatAPI >> initializeWithBaseURL: initialBaseURL system: initialSystem [
+OpenAIChatAPI >> initializeWithBaseURL: initialBaseURL apiKey: initialAPIKey system: initialSystem [
 
 	self initialize.
 	baseURL := initialBaseURL.
+	apiKey := initialAPIKey.
 	system := initialSystem.
 	self model: self modelNames first.
 ]

--- a/src/AI-ChatPharo/OpenAIChatAPI.class.st
+++ b/src/AI-ChatPharo/OpenAIChatAPI.class.st
@@ -74,7 +74,8 @@ OpenAIChatAPI >> getResponseForHistory: history [
 		post;
 		response.
 	response isSuccess ifFalse: [ Error signal: 'Could not get chat completion' ].
-	^ (((STONJSON fromString: response contents) at: 'choices') first at: 'message') at: 'content'
+	^ ChatPharoHistorySaver role: 'assistant'
+		content: ((((STONJSON fromString: response contents) at: 'choices') first at: 'message') at: 'content')
 ]
 
 { #category : 'initialization' }

--- a/src/AI-ChatPharo/OpenAIChatToolFunction.class.st
+++ b/src/AI-ChatPharo/OpenAIChatToolFunction.class.st
@@ -1,0 +1,98 @@
+Class {
+	#name : 'OpenAIChatToolFunction',
+	#superclass : 'Object',
+	#instVars : [
+		'name',
+		'description',
+		'block',
+		'parameters'
+	],
+	#category : 'AI-ChatPharo-OpenAI',
+	#package : 'AI-ChatPharo',
+	#tag : 'OpenAI'
+}
+
+{ #category : 'instance creation' }
+OpenAIChatToolFunction class >> name: functionName description: description parameters: parameters block: block [
+
+	^ self basicNew
+		initializeWithName: functionName description: description parameters: parameters block: block;
+		yourself
+
+]
+
+{ #category : 'examples' }
+OpenAIChatToolFunction class >> toolGetCurrentWeather [
+
+	<sampleInstance>
+	
+	| weatherDataPerCity |
+	
+	weatherDataPerCity := Dictionary with: 'Paris' ->
+		(Dictionary with: 'degrees_centigrade' -> 10 with: 'precipitation' -> 'rain').
+	^ self name: 'get_current_weather'
+		description: 'Get the current weather for a city.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'city' -> (Dictionary
+					with: 'type' -> 'string'
+					with: 'description' -> 'The name of the city'))
+			with: 'required' -> #('city'))
+		block: [ :arguments | 
+			(arguments at: 'city') in: [ :city |
+				weatherDataPerCity at: city ifAbsent: [
+					Dictionary with: 'error' -> ('No weather data available for ' , city) ] ] ]
+]
+
+{ #category : 'applying' }
+OpenAIChatToolFunction >> applyTo: arguments [
+
+	^ block value: arguments
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolFunction >> block [
+
+	^ block
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolFunction >> description [
+
+	^ description
+]
+
+{ #category : 'initialization' }
+OpenAIChatToolFunction >> initializeWithName: initialName description: initialDescription parameters: initialParameters block: initialBlock [
+
+	self initialize.
+	name := initialName.
+	description := initialDescription.
+	parameters := initialParameters.
+	block := initialBlock.
+
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolFunction >> name [
+
+	^ name
+]
+
+{ #category : 'openAI API' }
+OpenAIChatToolFunction >> openAIChatTool [
+
+	^ Dictionary
+		with: 'type' -> 'function'
+		with: 'function' -> (Dictionary
+			with: 'name' -> name
+			with: 'description' -> description
+			with: 'parameters' -> parameters)
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolFunction >> parameters [
+
+	^ parameters
+]

--- a/src/AI-ChatPharo/OpenAIChatToolFunction.class.st
+++ b/src/AI-ChatPharo/OpenAIChatToolFunction.class.st
@@ -22,6 +22,36 @@ OpenAIChatToolFunction class >> name: functionName description: description para
 ]
 
 { #category : 'examples' }
+OpenAIChatToolFunction class >> toolEvaluateExpression [
+
+	<sampleInstance>
+	
+	^ self name: 'evaluate_expression'
+		description: 'Evaluates a Smalltalk expression in the user''s Pharo image.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'expression' -> (Dictionary
+					with: 'type' -> 'string'
+					with: 'description' -> 'The Smalltalk expression to evaluate'))
+			with: 'required' -> #('expression'))
+		block: [ :arguments |
+			| expression result value |
+			expression := arguments at: 'expression'.
+			[ :exitBlock |
+				[ OCParser parseExpression: expression ] on: OCCodeError do: [ :error |
+					result := Dictionary with: 'syntax_error' -> ('Syntax error in given expression at position {1}: {2}' format:
+						{ error position. error messageText }).
+					exitBlock value ].
+				[ value := Smalltalk compiler evaluate: expression ] on: Error do: [ :error |
+					result := Dictionary with: 'evaluation_error' -> error asString.
+					exitBlock value ].
+				result := Dictionary with: 'value' -> value asString
+			] valueWithExit.
+			result ]
+]
+
+{ #category : 'examples' }
 OpenAIChatToolFunction class >> toolGetCurrentWeather [
 
 	<sampleInstance>
@@ -43,6 +73,37 @@ OpenAIChatToolFunction class >> toolGetCurrentWeather [
 			(arguments at: 'city') in: [ :city |
 				weatherDataPerCity at: city ifAbsent: [
 					Dictionary with: 'error' -> ('No weather data available for ' , city) ] ] ]
+]
+
+{ #category : 'examples' }
+OpenAIChatToolFunction class >> toolOpenPlayground [
+
+	<sampleInstance>
+	
+	^ self name: 'open_playground'
+		description: (' ' join: #('Opens a Pharo Playground with the given Smalltalk code in the user''s image so that the user'
+			'can edit and execute the code. As this opens another window, use only when sure it''s what the user intended,'
+			'or ask first. Use this to give code examples. If the code has a syntax error, the error is reported to you and'
+			'no Playground is opened.'))
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'code' -> (Dictionary
+					with: 'type' -> 'string'
+					with: 'description' -> 'The Pharo Smalltalk code for the Playground'))
+			with: 'required' -> #('code'))
+		block: [ :arguments | 
+			| code result |
+			code := arguments at: 'code'.
+			[ :exitBlock |
+				[ OCParser parseExpression: code ] on: OCCodeError do: [ :error |
+					result := Dictionary with: 'syntax_error' -> ('Syntax error in given code at position {1}: {2}' format:
+						{ error position. error messageText }).
+					exitBlock value ].
+				StPlayground openContents: code.
+				result := Dictionary with: 'playground_opened' -> true
+			] valueWithExit.
+			result ]
 ]
 
 { #category : 'applying' }

--- a/src/AI-ChatPharo/OpenAIChatToolsetOnBrowserEnvironment.class.st
+++ b/src/AI-ChatPharo/OpenAIChatToolsetOnBrowserEnvironment.class.st
@@ -1,0 +1,304 @@
+Class {
+	#name : 'OpenAIChatToolsetOnBrowserEnvironment',
+	#superclass : 'Object',
+	#instVars : [
+		'browserEnvironment',
+		'tools'
+	],
+	#category : 'AI-ChatPharo-OpenAI',
+	#package : 'AI-ChatPharo',
+	#tag : 'OpenAI'
+}
+
+{ #category : 'instance creation' }
+OpenAIChatToolsetOnBrowserEnvironment class >> browserEnvironment: browserEnvironment [
+
+	^ self basicNew initializeWithEnvironment: browserEnvironment; yourself
+
+]
+
+{ #category : 'instance creation' }
+OpenAIChatToolsetOnBrowserEnvironment class >> new [
+
+	^ self browserEnvironment: RBBrowserEnvironment default
+
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionFindMethodsWithSubstring: arguments [
+
+	| substring methods |
+
+	substring := arguments at: 'substring'.
+	methods := self methodsWithSubstring: substring cappedAt: 50.
+
+	^ Dictionary with: 'methods' -> (methods collect: [ :method |
+		Dictionary
+			with: 'class' -> method methodClass instanceSide name
+			with: 'side' -> (method methodClass hasClassSide ifTrue: [ 'instance' ] ifFalse: [ 'class' ])
+			with: 'protocol' -> method protocolName
+			with: 'selector' -> method selector
+			with: 'source' -> method sourceCode ]) asArray
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetClassComments: arguments [
+
+	^ self response: 'comment_per_class'
+		collect: [ :class | class comment ]
+		forClassesNamed: (arguments at: 'classes')
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetClassDefinitions: arguments [
+
+	^ self response: 'definition_per_class'
+		collect: [ :class |
+			 Dictionary
+				with: 'superclass' -> (class superclass ifNotNil: [ :superclass | superclass name ])
+				with: 'instance_variables' -> class instVarNames
+				with: 'class_variables' -> class classVarNames
+				with: 'package' -> class package name
+				with: 'tag' -> class packageTagName ]
+		forClassesNamed: (arguments at: 'classes')
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetClassMethods: arguments [
+
+	| selectorsOnly |
+
+	selectorsOnly := arguments at: 'selectors_only'.
+	^ self response: (selectorsOnly ifTrue: [ 'selectors' ] ifFalse: [ 'methods' ]) , '_per_protocol_per_side_per_class'
+		collect: [ :class |
+			Dictionary newFrom: ({ class. class class } collect: [ :methodClass |
+				(methodClass isInstanceSide ifTrue: [ 'instance' ] ifFalse: [ 'class' ]) ->
+					(Dictionary newFrom: ((methodClass protocols sorted: [ :protocol1 :protocol2 | protocol1 name < protocol2 name ])
+						collect: [ :protocol |
+							| selectorsInProtocol |
+							selectorsInProtocol := (methodClass selectorsInProtocol: protocol) sorted.
+							protocol name -> (selectorsOnly ifTrue: [ selectorsInProtocol ] ifFalse: [
+								selectorsInProtocol collect: [ :selector | methodClass sourceCodeAt: selector ] ]) ])) ]) ]
+		forClassesNamed: (arguments at: 'classes')
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetClassSubclasses: arguments [
+
+	^ self response: 'subclasses_per_class'
+		collect: [ :class |
+			(class subclasses select: [ :subclass | self browserEnvironment includesClass: subclass ])
+				collect: [ :subclasses | subclasses name ] ]
+		forClassesNamed: (arguments at: 'classes')
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetClassesInPackages: arguments [
+
+	| classesPerPackage notFoundPackages |
+
+	classesPerPackage := Dictionary new.
+	notFoundPackages := OrderedCollection new.
+
+	(arguments at: 'packages') do: [ :packageName |
+		(self classesInPackageNamed: packageName) ifNotNil: [ :classes |
+			classesPerPackage at: packageName put:
+				((classes sorted: [ :class1 :class2 | class1 name < class2 name ]) collect: [ :class | class name ])
+		] ifNil: [
+			notFoundPackages add: packageName ] ].
+
+	^ Dictionary with: 'classes_per_package' -> classesPerPackage with: 'nonexistent_or_outside_scope_packages' -> notFoundPackages asArray
+]
+
+{ #category : 'private - function implementations' }
+OpenAIChatToolsetOnBrowserEnvironment >> applyFunctionGetPackages: arguments [
+
+	^ Dictionary with: 'packages' -> (self browserEnvironment packages collect: [ :package | package name ]) sorted
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolsetOnBrowserEnvironment >> browserEnvironment [
+
+	^ browserEnvironment
+]
+
+{ #category : 'private' }
+OpenAIChatToolsetOnBrowserEnvironment >> classNamed: className [
+
+	^ self browserEnvironment at: className asSymbol ifAbsent: [ nil ]
+]
+
+{ #category : 'private' }
+OpenAIChatToolsetOnBrowserEnvironment >> classesInPackageNamed: packageName [
+
+	^ (self packageNamed: packageName) ifNotNil: [ :package |
+		package definedClasses select: [ :class | self browserEnvironment includesClass: class ] ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionFindMethodsWithSubstring [
+
+	^ OpenAIChatToolFunction name: 'find_methods_with_substring'
+		description: 'Finds methods whose source includes the given substring. Results are capped at 50 methods.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'substring' -> (Dictionary
+					with: 'type' -> 'string'
+					with: 'description' -> 'The substring to find'))
+			with: 'required' -> #('substring'))
+		block: [ :arguments | self applyFunctionFindMethodsWithSubstring: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetClassComments [
+
+	^ OpenAIChatToolFunction name: 'get_class_comments'
+		description: 'Gets the comment of each class.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'classes' -> (Dictionary
+					with: 'type' -> 'array'
+					with: 'items' -> (Dictionary with: 'type' -> 'string')
+					with: 'description' -> 'Names of the classes'))
+			with: 'required' -> #('classes'))
+		block: [ :arguments | self applyFunctionGetClassComments: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetClassDefinitions [
+
+	^ OpenAIChatToolFunction name: 'get_class_definitions'
+		description: 'Gets the definitions of each class: its superclass, its instance variables, its class variables, the package it is in and its tag.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'classes' -> (Dictionary
+					with: 'type' -> 'array'
+					with: 'items' -> (Dictionary with: 'type' -> 'string')
+					with: 'description' -> 'Names of the classes'))
+			with: 'required' -> #('classes'))
+		block: [ :arguments | self applyFunctionGetClassDefinitions: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetClassMethods [
+
+	^ OpenAIChatToolFunction name: 'get_class_methods'
+		description: 'Gets the source code, or just the selectors, of each method for the given classes, organized per protocol and grouped by instance side and class side.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'classes' -> (Dictionary
+					with: 'type' -> 'array'
+					with: 'items' -> (Dictionary with: 'type' -> 'string')
+					with: 'description' -> 'Names of the classes')
+				with: 'selectors_only' -> (Dictionary
+					with: 'type' -> 'boolean'
+					with: 'description' -> ('Whether to get the full source of each method, or only its selector; ' ,
+						'prefer selectors only to get an overview of a class')))
+			with: 'required' -> #('classes' 'selectors_only'))
+		block: [ :arguments | self applyFunctionGetClassMethods: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetClassSubclasses [
+
+	^ OpenAIChatToolFunction name: 'get_class_subclasses'
+		description: 'Gets the subclasses of each given class.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'classes' -> (Dictionary
+					with: 'type' -> 'array'
+					with: 'items' -> (Dictionary with: 'type' -> 'string')
+					with: 'description' -> 'Names of the classes'))
+			with: 'required' -> #('classes'))
+		block: [ :arguments | self applyFunctionGetClassSubclasses: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetClassesInPackages [
+
+	^ OpenAIChatToolFunction name: 'get_classes_in_packages'
+		description: 'Gets the classes in each given package.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> (Dictionary
+				with: 'packages' -> (Dictionary
+					with: 'type' -> 'array'
+					with: 'items' -> (Dictionary with: 'type' -> 'string')
+					with: 'description' -> 'Names of the packages'))
+			with: 'required' -> #('packages'))
+		block: [ :arguments | self applyFunctionGetClassesInPackages: arguments ]
+]
+
+{ #category : 'private - function declarations' }
+OpenAIChatToolsetOnBrowserEnvironment >> functionGetPackages [
+
+	^ OpenAIChatToolFunction name: 'get_packages'
+		description: 'Gets all of the packages.'
+		parameters: (Dictionary
+			with: 'type' -> 'object'
+			with: 'properties' -> Dictionary new
+			with: 'required' -> #())
+		block: [ :arguments | self applyFunctionGetPackages: arguments ]
+]
+
+{ #category : 'initialize - release' }
+OpenAIChatToolsetOnBrowserEnvironment >> initializeWithEnvironment: initialBrowserEnvironment [
+
+	self initialize.
+	browserEnvironment := initialBrowserEnvironment.
+	tools := {
+		self functionGetPackages.
+		self functionGetClassesInPackages.
+		self functionGetClassDefinitions.
+		self functionGetClassComments.
+		self functionGetClassMethods.
+		self functionGetClassSubclasses.
+		self functionFindMethodsWithSubstring }.
+]
+
+{ #category : 'private' }
+OpenAIChatToolsetOnBrowserEnvironment >> methodsWithSubstring: substring cappedAt: maximumNumberOfMethods [
+
+	| methods |
+
+	methods := OrderedCollection new.
+	self browserEnvironment methodsDo: [ :method |
+		(method sourceCode includesSubstring: substring) ifTrue: [
+			methods add: method.
+			methods size = maximumNumberOfMethods ifTrue: [ ^ methods ] ] ].
+	^ methods
+]
+
+{ #category : 'private' }
+OpenAIChatToolsetOnBrowserEnvironment >> packageNamed: packageName [
+
+	^ self browserEnvironment packageAt: packageName ifAbsent: [ nil ]
+]
+
+{ #category : 'private' }
+OpenAIChatToolsetOnBrowserEnvironment >> response: resultKey collect: block forClassesNamed: classNames [
+
+	| resultPerClass classesNotFound |
+
+	resultPerClass := Dictionary new.
+	classesNotFound := OrderedCollection new.
+	
+	classNames do: [ :className |
+		(self classNamed: className) ifNotNil: [ :class |
+			 resultPerClass at: className put: (block value: class)
+		] ifNil: [
+			classesNotFound add: className ] ].
+
+	^ Dictionary with: resultKey -> resultPerClass with: 'nonexistent_or_outside_scope_classes' -> classesNotFound asArray
+]
+
+{ #category : 'accessing' }
+OpenAIChatToolsetOnBrowserEnvironment >> tools [
+
+	^ tools
+]


### PR DESCRIPTION
This pull request adds support for using OpenAI-compatible chat completion APIs with tool calling. I tried it with Ollama and Google Gemini. Presumably it should work with the actual OpenAI API as well, but I haven’t tried that.

Note that the `#saveCurrentChat` and `#loadChat` methods on ChatPharo are not adapted to take tool calls into account as `#loadChat` seemed incomplete to begin with.

The following screenshot shows a tool call example based on one given in the [UKSTUG presentation](https://www.youtube.com/watch?v=_eGda5Z7yAY) by @LinqLover on [SemanticText](https://github.com/hpi-swa-lab/Squeak-SemanticText):

<p align="center">
<img width="441" src="https://github.com/user-attachments/assets/cf4ca1cb-2080-4e37-b361-224a0b43b8d1">
</p>

The chat window was opened using the following:

```smalltalk
(ChatPharo on: (OpenAIChatAPI geminiWithAPIKey: geminiAPIKey
	system: 'You are an AI coding assistant within the user''s Pharo image.'
	tools: { OpenAIChatToolFunction toolEvaluateExpression })) open
```

The expression the model evaluated was: `(World submorphs select: [ :m | m isKindOf: SystemWindow ]) size`. I did pick a case here in which it gave the right answer, in other chats it tended to use `SystemWindow allInstances size` which doesn’t take into account that SystemWindow has subclasses nor that there can be instances that are closed but not yet garbage collected.

To use the ‘gemini-2.5-pro-preview-03-25’ model, you need a ‘Paid Tier’ Gemini API key. With a ‘Free Tier’ API key, ‘gemini-2.5-pro-exp-03-25’ can be used instead, but that has a limit of just 25 requests per day. See the sections on [‘API keys’](https://ai.google.dev/gemini-api/docs/api-key), [‘Pricing’](https://ai.google.dev/gemini-api/docs/pricing) and [‘Rate limits’](https://ai.google.dev/gemini-api/docs/rate-limits) in the [Gemini API docs](https://ai.google.dev/gemini-api/docs).