### PR TITLE
Add collapsible table of contents to documentation site

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -18,17 +18,36 @@
     </nav>
   </header>
 
-  <main>
-    <h2>Project Overview</h2>
-    <p>ChatPharo is a framework for intelligent completion and language tooling in Pharo, powered by modern language models.</p>
+  <div class="toc-toggle-container">
+    <button id="toc-toggle" class="toc-toggle" type="button" aria-expanded="true" aria-controls="toc">
+      Hide table of contents
+    </button>
+  </div>
 
-    <h2>Contributors</h2>
-    <p>Developed and maintained by the ChatPharo team and the open-source community.</p>
-  </main>
+  <div class="layout">
+    <aside id="toc" class="toc" aria-labelledby="toc-title">
+      <h2 id="toc-title" class="toc__title">Contents</h2>
+      <nav class="toc__nav" aria-label="Table of contents">
+        <ul class="toc__list"></ul>
+      </nav>
+    </aside>
+
+    <main>
+      <h2>Project Overview</h2>
+      <p>
+        ChatPharo is a framework for intelligent completion and language tooling in Pharo, powered by modern language models.
+      </p>
+
+      <h2>Contributors</h2>
+      <p>Developed and maintained by the ChatPharo team and the open-source community.</p>
+    </main>
+  </div>
 
   <footer>
     &copy; <span id="year"></span> ChatPharo Project.
   </footer>
+
+  <script src="assets/js/toc.js"></script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/docs/api.html
+++ b/docs/api.html
@@ -18,17 +18,34 @@
     </nav>
   </header>
 
-  <main>
-    <h2>Core Modules</h2>
-    <p>Details about the main modules and their usage.</p>
+  <div class="toc-toggle-container">
+    <button id="toc-toggle" class="toc-toggle" type="button" aria-expanded="true" aria-controls="toc">
+      Hide table of contents
+    </button>
+  </div>
 
-    <h2>Classes & Methods</h2>
-    <p>Comprehensive reference of classes, methods, and parameters.</p>
-  </main>
+  <div class="layout">
+    <aside id="toc" class="toc" aria-labelledby="toc-title">
+      <h2 id="toc-title" class="toc__title">Contents</h2>
+      <nav class="toc__nav" aria-label="Table of contents">
+        <ul class="toc__list"></ul>
+      </nav>
+    </aside>
+
+    <main>
+      <h2>Core Modules</h2>
+      <p>Details about the main modules and their usage.</p>
+
+      <h2>Classes &amp; Methods</h2>
+      <p>Comprehensive reference of classes, methods, and parameters.</p>
+    </main>
+  </div>
 
   <footer>
     &copy; <span id="year"></span> ChatPharo Project.
   </footer>
+
+  <script src="assets/js/toc.js"></script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -17,7 +17,7 @@ body {
 header {
   padding: 2rem 1rem;
   background: white;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.05);
   text-align: center;
 }
 
@@ -30,6 +30,11 @@ h1 {
 h2 {
   color: var(--primary);
   margin: 2rem 0 1rem;
+}
+
+h3 {
+  color: var(--primary);
+  margin: 1.5rem 0 0.75rem;
 }
 
 p {
@@ -55,10 +60,117 @@ nav a:hover {
   color: #005f99;
 }
 
-main {
-  padding: 2rem 1rem;
-  max-width: 900px;
+.toc-toggle-container {
+  max-width: 1200px;
+  margin: 1rem auto 0;
+  padding: 0 1rem;
+  text-align: right;
+}
+
+.toc-toggle {
+  background: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.toc-toggle:hover {
+  background: #005f99;
+  transform: translateY(-1px);
+}
+
+.toc-toggle:focus-visible {
+  outline: 3px solid rgba(0, 122, 204, 0.35);
+  outline-offset: 2px;
+}
+
+.layout {
+  display: flex;
+  gap: 2rem;
+  max-width: 1200px;
   margin: 0 auto;
+  padding: 2rem 1rem;
+  align-items: flex-start;
+}
+
+.toc {
+  position: sticky;
+  top: 2rem;
+  align-self: flex-start;
+  min-width: 220px;
+  max-width: 280px;
+  background: white;
+  border-radius: 12px;
+  padding: 1.25rem 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+}
+
+.toc--collapsed {
+  display: none;
+}
+
+.toc__title {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.toc__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.toc__link {
+  display: block;
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  border-left: 3px solid transparent;
+  padding-left: 0.5rem;
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.toc__link:hover,
+.toc__link:focus-visible {
+  color: var(--primary);
+  border-color: var(--primary);
+  transform: translateX(2px);
+}
+
+.toc__item--level-h3 .toc__link {
+  font-size: 0.9rem;
+  padding-left: 1.25rem;
+}
+
+main {
+  flex: 1;
+  max-width: 720px;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+main h2,
+main h3,
+main p {
+  text-align: left;
+}
+
+main p {
+  margin: 0.5rem 0;
 }
 
 footer {
@@ -67,4 +179,22 @@ footer {
   font-size: 0.9rem;
   text-align: center;
   color: var(--muted);
+}
+
+@media (max-width: 900px) {
+  .toc-toggle-container {
+    text-align: left;
+  }
+
+  .layout {
+    flex-direction: column;
+    padding-top: 1.5rem;
+  }
+
+  .toc {
+    position: static;
+    width: 100%;
+    max-width: none;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+  }
 }

--- a/docs/assets/js/toc.js
+++ b/docs/assets/js/toc.js
@@ -1,0 +1,85 @@
+(function () {
+  const layoutReady = () => {
+    const toc = document.getElementById('toc');
+    const toggleButton = document.getElementById('toc-toggle');
+    const toggleContainer = toggleButton ? toggleButton.closest('.toc-toggle-container') : null;
+    const list = toc ? toc.querySelector('.toc__list') : null;
+    const main = document.querySelector('main');
+    if (!toc || !toggleButton || !list || !main) {
+      return;
+    }
+
+    const headings = Array.from(main.querySelectorAll('h2, h3'));
+    if (!headings.length) {
+      toc.setAttribute('hidden', '');
+      toggleButton.setAttribute('hidden', '');
+      if (toggleContainer) {
+        toggleContainer.setAttribute('hidden', '');
+      }
+      return;
+    }
+
+    const slugCounts = new Map();
+    const slugify = (text) => {
+      const baseSlug = text
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-');
+      const safeSlug = baseSlug || 'section';
+      const count = slugCounts.get(safeSlug) || 0;
+      slugCounts.set(safeSlug, count + 1);
+      return count ? `${safeSlug}-${count + 1}` : safeSlug;
+    };
+
+    headings.forEach((heading) => {
+      if (!heading.id) {
+        heading.id = slugify(heading.textContent || heading.innerText || 'section');
+      }
+
+      const listItem = document.createElement('li');
+      listItem.classList.add('toc__item', `toc__item--level-${heading.tagName.toLowerCase()}`);
+
+      const link = document.createElement('a');
+      link.className = 'toc__link';
+      link.href = `#${heading.id}`;
+      link.textContent = heading.textContent || heading.innerText || heading.id;
+
+      listItem.appendChild(link);
+      list.appendChild(listItem);
+    });
+
+    const collapse = () => {
+      toc.classList.add('toc--collapsed');
+      toggleButton.setAttribute('aria-expanded', 'false');
+      toggleButton.textContent = 'Show table of contents';
+    };
+
+    const expand = () => {
+      toc.classList.remove('toc--collapsed');
+      toggleButton.setAttribute('aria-expanded', 'true');
+      toggleButton.textContent = 'Hide table of contents';
+    };
+
+    toggleButton.addEventListener('click', () => {
+      if (toc.classList.contains('toc--collapsed')) {
+        expand();
+      } else {
+        collapse();
+      }
+    });
+
+    if (window.matchMedia('(max-width: 900px)').matches) {
+      collapse();
+    } else {
+      expand();
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', layoutReady);
+  } else {
+    layoutReady();
+  }
+})();

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -18,17 +18,34 @@
     </nav>
   </header>
 
-  <main>
-    <h2>Installation</h2>
-    <p>Instructions for installing ChatPharo will go here.</p>
+  <div class="toc-toggle-container">
+    <button id="toc-toggle" class="toc-toggle" type="button" aria-expanded="true" aria-controls="toc">
+      Hide table of contents
+    </button>
+  </div>
 
-    <h2>Quick Example</h2>
-    <p>A short example showing how to use ChatPharo.</p>
-  </main>
+  <div class="layout">
+    <aside id="toc" class="toc" aria-labelledby="toc-title">
+      <h2 id="toc-title" class="toc__title">Contents</h2>
+      <nav class="toc__nav" aria-label="Table of contents">
+        <ul class="toc__list"></ul>
+      </nav>
+    </aside>
+
+    <main>
+      <h2>Installation</h2>
+      <p>Instructions for installing ChatPharo will go here.</p>
+
+      <h2>Quick Example</h2>
+      <p>A short example showing how to use ChatPharo.</p>
+    </main>
+  </div>
 
   <footer>
     &copy; <span id="year"></span> ChatPharo Project.
   </footer>
+
+  <script src="assets/js/toc.js"></script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -18,17 +18,34 @@
     </nav>
   </header>
 
-  <main>
-    <h2>Tutorials</h2>
-    <p>Step-by-step guides to help you get the most out of ChatPharo.</p>
+  <div class="toc-toggle-container">
+    <button id="toc-toggle" class="toc-toggle" type="button" aria-expanded="true" aria-controls="toc">
+      Hide table of contents
+    </button>
+  </div>
 
-    <h2>Best Practices</h2>
-    <p>Recommended workflows and design patterns.</p>
-  </main>
+  <div class="layout">
+    <aside id="toc" class="toc" aria-labelledby="toc-title">
+      <h2 id="toc-title" class="toc__title">Contents</h2>
+      <nav class="toc__nav" aria-label="Table of contents">
+        <ul class="toc__list"></ul>
+      </nav>
+    </aside>
+
+    <main>
+      <h2>Tutorials</h2>
+      <p>Step-by-step guides to help you get the most out of ChatPharo.</p>
+
+      <h2>Best Practices</h2>
+      <p>Recommended workflows and design patterns.</p>
+    </main>
+  </div>
 
   <footer>
     &copy; <span id="year"></span> ChatPharo Project.
   </footer>
+
+  <script src="assets/js/toc.js"></script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,8 @@
 
   <!-- Styles -->
   <link rel="stylesheet" href="assets/css/style.css" />
-</head><body>
+</head>
+<body>
   <header>
     <h1>📘 ChatPharo Documentation</h1>
     <p>A framework for intelligent completion and language tooling in Pharo.</p>
@@ -31,15 +32,34 @@
     </nav>
   </header>
 
-  <main>
-    <h2>Welcome</h2>
-    <p>This site contains the official documentation and wiki for <strong>ChatPharo</strong>. Use the navigation links above to explore guides, tutorials, and API references.</p>
-  </main>
+  <div class="toc-toggle-container">
+    <button id="toc-toggle" class="toc-toggle" type="button" aria-expanded="true" aria-controls="toc">
+      Hide table of contents
+    </button>
+  </div>
+
+  <div class="layout">
+    <aside id="toc" class="toc" aria-labelledby="toc-title">
+      <h2 id="toc-title" class="toc__title">Contents</h2>
+      <nav class="toc__nav" aria-label="Table of contents">
+        <ul class="toc__list"></ul>
+      </nav>
+    </aside>
+
+    <main>
+      <h2>Welcome</h2>
+      <p>
+        This site contains the official documentation and wiki for <strong>ChatPharo</strong>. Use the navigation links above
+        to explore guides, tutorials, and API references.
+      </p>
+    </main>
+  </div>
 
   <footer>
     &copy; <span id="year"></span> ChatPharo Project. All rights reserved.
   </footer>
 
+  <script src="assets/js/toc.js"></script>
   <script>document.getElementById('year').textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable sidebar layout with a toggleable table of contents across the documentation pages
- add responsive styles for the sidebar, toggle button, and main content layout
- generate the table of contents links automatically from page headings with a shared script

## Testing
- no automated tests (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68d9752c91a88320845cdba9851f37dc